### PR TITLE
Add simple login screen and logout support

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Akiba Digital Quotation Tool</title>
+  <script>
+    if (!localStorage.getItem('loggedIn')) {
+      window.location.href = 'login.html';
+    }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
@@ -27,6 +32,7 @@
         <label>Quote #
           <input type="text" id="quoteNumber" placeholder="AKB-0001" />
         </label>
+        <button type="button" id="logoutBtn" class="secondary">Log Out</button>
       </div>
     </header>
 

--- a/login.html
+++ b/login.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Akiba Digital – Sign In</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    body {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      margin: 0;
+      background: linear-gradient(to bottom, #f9fafb, #e5e7eb);
+      font-family: 'Inter', Arial, sans-serif;
+    }
+    .login-card {
+      background: #fff;
+      padding: 2rem;
+      border-radius: 8px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+      width: 100%;
+      max-width: 360px;
+    }
+    .login-card h1 {
+      margin-top: 0;
+      margin-bottom: 1.5rem;
+      text-align: center;
+      color: #20335b;
+      font-size: 1.5rem;
+    }
+    .login-card label {
+      display: block;
+      margin-bottom: 1rem;
+    }
+    .login-card input {
+      width: 100%;
+      padding: 0.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 4px;
+      margin-top: 0.25rem;
+      box-sizing: border-box;
+    }
+    .login-card button {
+      width: 100%;
+      padding: 0.6rem;
+      background-color: #20335b;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .login-card button:hover {
+      background-color: #314472;
+    }
+  </style>
+</head>
+<body>
+  <form class="login-card" id="loginForm">
+    <h1>Sign In</h1>
+    <label>Email
+      <input type="email" id="loginEmail" required />
+    </label>
+    <label>Password
+      <input type="password" id="loginPassword" required />
+    </label>
+    <button type="submit">Login</button>
+  </form>
+  <script src="login.js"></script>
+</body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,18 @@
+window.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('loggedIn')) {
+    window.location.href = 'Index.html';
+    return;
+  }
+
+  const form = document.getElementById('loginForm');
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    // A real login would verify credentials server-side.
+    // This demo simply stores a flag in localStorage.
+    const email = document.getElementById('loginEmail').value.trim();
+    const password = document.getElementById('loginPassword').value.trim();
+    if (!email || !password) return;
+    localStorage.setItem('loggedIn', 'true');
+    window.location.href = 'Index.html';
+  });
+});

--- a/script.js
+++ b/script.js
@@ -855,4 +855,12 @@ window.addEventListener("DOMContentLoaded", () => {
   });
 
   document.getElementById("downloadBtn").addEventListener("click", downloadQuoteAsPDF);
+
+  const logout = document.getElementById("logoutBtn");
+  if (logout) {
+    logout.addEventListener("click", () => {
+      localStorage.removeItem("loggedIn");
+      window.location.href = "login.html";
+    });
+  }
 });

--- a/style.css
+++ b/style.css
@@ -37,6 +37,9 @@ body {
   flex-direction: column;
   margin-bottom: 0.5rem;
 }
+.meta button {
+  margin-top: 1.5rem;
+}
 
 h1 {
   color: #20335b;


### PR DESCRIPTION
## Summary
- require authentication via a new `login.html` page
- redirect `Index.html` to the login screen when not authenticated
- support signing in/out via `login.js` and logout button
- style logout button

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688c8b4b37a4832bb0ff2349810e93f0