### PR TITLE
Add quote approval workflow with Slack integration

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -144,6 +144,8 @@
 
       <div class="actions">
         <button type="submit">Generate Quote Preview</button>
+        <button type="button" id="approvalBtn" class="secondary" style="display:none;">Send for Approval</button>
+        <button type="button" id="statusBtn" class="secondary" style="display:none;">Check Status</button>
         <button type="button" id="downloadBtn" class="secondary" style="display:none;">Download PDF</button>
       </div>
     </form>

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Quote Approvals</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Pending Quotes</h1>
+    <table id="quotesTable">
+      <thead>
+        <tr><th>ID</th><th>Status</th><th>Actions</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,33 @@
+function loadQuotes() {
+  const tbody = document.querySelector('#quotesTable tbody');
+  tbody.innerHTML = '';
+  Object.keys(localStorage).forEach(key => {
+    if (key.startsWith('quote_')) {
+      const q = JSON.parse(localStorage.getItem(key));
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${q.id}</td><td class="status">${q.status}</td>` +
+        `<td><button data-id="${q.id}" class="view-btn">View</button> ` +
+        `<button data-id="${q.id}" class="approve-btn">Approve</button></td>`;
+      tbody.appendChild(tr);
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadQuotes();
+  document.querySelector('#quotesTable').addEventListener('click', (e) => {
+    const id = e.target.dataset.id;
+    if (!id) return;
+    const key = 'quote_' + id;
+    const obj = JSON.parse(localStorage.getItem(key));
+    if (e.target.classList.contains('view-btn')) {
+      const w = window.open('', '_blank');
+      w.document.write(obj.html || '');
+    }
+    if (e.target.classList.contains('approve-btn')) {
+      obj.status = 'approved';
+      localStorage.setItem(key, JSON.stringify(obj));
+      e.target.closest('tr').querySelector('.status').textContent = 'approved';
+    }
+  });
+});

--- a/script.js
+++ b/script.js
@@ -904,4 +904,12 @@ window.addEventListener("DOMContentLoaded", () => {
       document.getElementById("statusBtn").style.display = "inline-block";
     }
   }
+
+  const logout = document.getElementById("logoutBtn");
+  if (logout) {
+    logout.addEventListener("click", () => {
+      localStorage.removeItem("loggedIn");
+      window.location.href = "login.html";
+    });
+  }
 });

--- a/script.js
+++ b/script.js
@@ -22,6 +22,9 @@ const decisionPrices = {
   enterprise: 0.8,
 };
 
+// URL for Slack incoming webhook. Replace with your actual webhook URL.
+const SLACK_WEBHOOK_URL = "";
+
 const products = {
   "/api/bankstatement/behavioral-risk": {
     description: "Behavioural Risk Score",
@@ -832,6 +835,38 @@ function downloadQuoteAsPDF() {
   };
 }
 
+function sendForApproval() {
+  const html = window.latestQuoteHTML;
+  if (!html) return;
+  const id = Date.now();
+  const quote = { id, html, status: 'pending' };
+  localStorage.setItem('quote_' + id, JSON.stringify(quote));
+  localStorage.setItem('currentQuoteId', id);
+  if (SLACK_WEBHOOK_URL) {
+    fetch(SLACK_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: `New quote awaiting approval: ${id}` })
+    });
+  }
+  alert('Quote sent for approval.');
+  document.getElementById('approvalBtn').style.display = 'none';
+  document.getElementById('statusBtn').style.display = 'inline-block';
+}
+
+function checkApprovalStatus() {
+  const id = localStorage.getItem('currentQuoteId');
+  if (!id) { alert('No quote submitted.'); return; }
+  const data = JSON.parse(localStorage.getItem('quote_' + id) || '{}');
+  if (data.status === 'approved') {
+    alert('Quote approved. You can download the PDF.');
+    document.getElementById('downloadBtn').style.display = 'inline-block';
+    document.getElementById('statusBtn').style.display = 'none';
+  } else {
+    alert('Still awaiting approval.');
+  }
+}
+
 window.addEventListener("DOMContentLoaded", () => {
   const qd = document.getElementById("quoteDate");
   if (qd && !qd.value) qd.value = new Date().toISOString().slice(0, 10);
@@ -850,9 +885,23 @@ window.addEventListener("DOMContentLoaded", () => {
     const totals = recalcAll();
     const html = renderQuoteHTML(totals);
     document.getElementById("quoteResult").innerHTML = html;
-    document.getElementById("downloadBtn").style.display = "inline-block";
+    document.getElementById("downloadBtn").style.display = "none";
+    document.getElementById("approvalBtn").style.display = "inline-block";
+    document.getElementById("statusBtn").style.display = "none";
     window.latestQuoteHTML = html;
   });
 
   document.getElementById("downloadBtn").addEventListener("click", downloadQuoteAsPDF);
+  document.getElementById("approvalBtn").addEventListener("click", sendForApproval);
+  document.getElementById("statusBtn").addEventListener("click", checkApprovalStatus);
+
+  const existingId = localStorage.getItem('currentQuoteId');
+  if (existingId) {
+    const data = JSON.parse(localStorage.getItem('quote_' + existingId) || '{}');
+    if (data.status === 'approved') {
+      document.getElementById("downloadBtn").style.display = "inline-block";
+    } else if (data.status === 'pending') {
+      document.getElementById("statusBtn").style.display = "inline-block";
+    }
+  }
 });


### PR DESCRIPTION
## Summary
- add approval and status buttons
- notify Slack via webhook and track approval in localStorage
- add admin page to review and approve quotes

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_688c8d0d2f90832bb430771bb5b3b932